### PR TITLE
Updated clearfix

### DIFF
--- a/lib/nib/clearfix.styl
+++ b/lib/nib/clearfix.styl
@@ -1,21 +1,31 @@
 
 /*
- * The Magnificent CLEARFIX.
+ * The Magnificent Micro Clearfix
  *
- * Useful for clearing floats without structural markup. This specific
- * clearfix method also prevents margin-collapsing on child elements.
+ * Useful for clearing floats without structural markup.
+ * Prevents margin-collapsing on child elements in most cases.
  *
- * See http://j.mp/bestclearfix
+ * Known issues:
+ *
+ * 1. For IE 6/7 when applied to an element that contains only left-floated
+ *    children the bottom margin on child elements will be collapsed.
+ *
+ * 2. For Firefox versions prior to 3.5 when applied to the first child element
+ *    of body, and the element does not have non-zero padding, extra space will
+ *    appear between the body and the first child.
+ *
+ * See http://nicolasgallagher.com/micro-clearfix-hack/
+ * and http://j.mp/bestclearfix
  *
  */
 
 clearfix()
   &:before
   &:after
-    content: "\0020"
-    display: block
-    height: 0
-    overflow: hidden
+    content: ""
+    display: table
   &:after
     clear: both
-  zoom: 1
+  /* For IE 6/7 support trigger hasLayout */
+  if support-for-ie
+    zoom: 1

--- a/lib/nib/index.styl
+++ b/lib/nib/index.styl
@@ -3,6 +3,7 @@
 @import 'text'
 @import 'reset'
 @import 'positions'
+@import 'clearfix'
 @import 'iconic'
 @import 'gradients'
 @import 'buttons'

--- a/test/cases/clearfix.css
+++ b/test/cases/clearfix.css
@@ -3,10 +3,8 @@
 }
 #clearfix:before,
 #clearfix:after {
-  content: "\0020";
-  display: block;
-  height: 0;
-  overflow: hidden;
+  content: "";
+  display: table;
 }
 #clearfix:after {
   clear: both;

--- a/test/cases/clearfix.styl
+++ b/test/cases/clearfix.styl
@@ -1,5 +1,7 @@
 
 @import 'nib/clearfix'
 
+support-for-ie = true
+
 #clearfix
   clearfix()

--- a/test/clearfix.styl
+++ b/test/clearfix.styl
@@ -1,12 +1,19 @@
-
 @import 'nib/clearfix'
 
-#clearfix
-  clearfix()
-  background-color: green
-  padding: 5px
+support-for-ie = true
 
-#clearfix div
-  background-color: blue
-  width: 30%
-  float: left
+#clearfix-left-only,
+#clearfix-left-right
+  clearfix()
+  background: blue
+  div
+    background: green
+    margin: 10px
+    width: 47%
+  div.left
+    float: left
+  div.right
+    float: right
+
+#clearfix-left-right
+  margin-top: 10px

--- a/test/index.jade
+++ b/test/index.jade
@@ -48,10 +48,20 @@ html
           - each name in names
             td: button(class=name).focus= name
     h2 Clearfix
-    div#clearfix
+    div#clearfix-left-only
       div
         | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut commodo
         | turpis quis mauris tempus commodo a non tellus. Sed eu convallis
         | mauris. Donec scelerisque lacus quis orci viverra tincidunt. Nunc sed
         | risus lectus. Proin vulputate elit sed eros consectetur interdum.
-      | Suspendisse potenti.
+    div#clearfix-left-right
+      div.left
+        | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut commodo
+        | turpis quis mauris tempus commodo a non tellus. Sed eu convallis
+        | mauris. Donec scelerisque lacus quis orci viverra tincidunt. Nunc sed
+        | risus lectus. Proin vulputate elit sed eros consectetur interdum.
+      div.right
+        | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut commodo
+        | turpis quis mauris tempus commodo a non tellus. Sed eu convallis
+        | mauris. Donec scelerisque lacus quis orci viverra tincidunt. Nunc sed
+        | risus lectus. Proin vulputate elit sed eros consectetur interdum.


### PR DESCRIPTION
A clearfix method requiring fewer CSS properties was first discussed [on this blog post](http://nicolasgallagher.com/micro-clearfix-hack/)

html5-boilerplate was subsequently updated paulirish/html5-boilerplate@ac92ae7a5f1762bc1ec9d45f1d76a41baf641b5a

I did my own extensive testing in IE 6/7/8/9/10pre, Chrome 11/12, Safari 5, Firefox 3.0/3.6/4, Opera 10.63/11 and mobile Safari. Found only one regression between the two methods. In Firefox versions prior to 3.5 if the clearfix is applied to the first child of the body and the first child does not have non-zero padding then extra space will appear between the first child and the body as reported on the blog post. 

I think that the one edge case with legacy Firefox versions is not worth the extra properties.

Imported clearfix in the index so it can be easily used when including the whole of nib via stylus include.

Used the support-for-ie variable to toggle zoom:1 as turned off it saves a few lines of compiled CSS per use of the mixin.

Also updated the comment noting the Firefox regression and a IE 6/7 issue that is the same between both clearfix methods. 

I think this is pretty much done so now I can move onto working on other interesting things for nib =)

Cheers,
Isaac 
