### PR TITLE
More moderate text-indent in hide-text()

### DIFF
--- a/lib/nib/text/hide-text.styl
+++ b/lib/nib/text/hide-text.styl
@@ -1,9 +1,8 @@
-
 /*
  * Hide text.
  */
 
 hide-text()
-  text-indent: -999999999em
+  text-indent: -99999em
   overflow: hidden
   text-align: left


### PR DESCRIPTION
Lowered text-indent to a moderate -99999em, since my browser (Chromium 13.0.767.1 on Linux amd64) won't hide text if text-indent is below -6990506em.
