### PR TITLE
New tests plus box.styl

### DIFF
--- a/lib/nib/box.styl
+++ b/lib/nib/box.styl
@@ -1,0 +1,22 @@
+/*
+ *
+ * Synopsis:
+ *
+ *   box: orient direction
+ *
+ * Examples:
+ *
+ *     box: horizontal
+ *     box: horizontal reverse
+ *
+ */
+
+box(args)
+  for prefix in vendor-prefixes
+      if official == prefix
+        {display}: box
+      else
+        {display}: unquote('-') + prefix + '-box'
+  box-orient: arguments[0]
+  if arguments[1]
+    box-direction: arguments[1]

--- a/lib/nib/index.styl
+++ b/lib/nib/index.styl
@@ -7,3 +7,4 @@
 @import 'iconic'
 @import 'gradients'
 @import 'buttons'
+@import 'box'

--- a/lib/nib/vendor.styl
+++ b/lib/nib/vendor.styl
@@ -78,6 +78,13 @@ column-rule-style()
   vendor('column-rule-style', arguments)
 
 /*
+ * Vendor "column-width" support.
+ */
+
+column-width()
+  vendor('column-width', arguments)
+
+/*
  * Vendor "background-size" support.
  */
 

--- a/test/cases/box.styl
+++ b/test/cases/box.styl
@@ -1,0 +1,9 @@
+
+@import 'nib/vendor'
+@import 'nib/box'
+
+section
+  box: horizontal
+
+section
+  box: horizontal reverse

--- a/test/cases/vendor.css
+++ b/test/cases/vendor.css
@@ -92,6 +92,23 @@ section {
   -webkit-column-rule-color: #bbb;
   -moz-column-rule-color: #bbb;
   column-rule-color: #bbb;
+  -webkit-column-width: 200px;
+  -moz-column-width: 200px;
+  column-width: 200px;
+}
+section {
+  -webkit-column-count: 2;
+  -moz-column-count: 2;
+  column-count: 2;
+  -webkit-column-rule-width: 1px;
+  -moz-column-rule-width: 1px;
+  column-rule-width: 1px;
+  -webkit-column-rule-style: solid;
+  -moz-column-rule-style: solid;
+  column-rule-style: solid;
+  -webkit-column-rule-color: #bbb;
+  -moz-column-rule-color: #bbb;
+  column-rule-color: #bbb;
   -webkit-column-gap: 2em;
   -moz-column-gap: 2em;
   column-gap: 2em;

--- a/test/cases/vendor.styl
+++ b/test/cases/vendor.styl
@@ -50,6 +50,13 @@ section
   column-rule-width: 1px;
   column-rule-style: solid;
   column-rule-color: #bbb;
+  column-width: 200px;
+
+section
+  column-count: 2;
+  column-rule-width: 1px;
+  column-rule-style: solid;
+  column-rule-color: #bbb;
   column-gap: 2em;
 
 prepend(vendor-prefixes, o)


### PR DESCRIPTION
Added box.styl which allows to wrote such code:

box: horizontal reverse;

And following CSS will be generated:

  display: -webkit-box;
  display: -moz-box;
  display: box;
  -webkit-box-orient: horizontal;
  -moz-box-orient: horizontal;
  box-orient: horizontal;
  -webkit-box-direction: reverse;
  -moz-box-direction: reverse;
  box-direction: reverse;

Implemented in the same way as positions: fixed, absolute etc.
