### PR TITLE
Remove <font> from the global-reset() helper.

### DIFF
--- a/lib/nib/reset.styl
+++ b/lib/nib/reset.styl
@@ -4,7 +4,7 @@ global-reset()
   html, body, div, span, applet, object, iframe,
   h1, h2, h3, h4, h5, h6, p, blockquote, pre,
   a, abbr, acronym, address, big, cite, code,
-  del, dfn, em, font, img, ins, kbd, q, s, samp,
+  del, dfn, em, img, ins, kbd, q, s, samp,
   small, strike, strong, sub, sup, tt, var,
   dl, dt, dd, ol, ul, li,
   fieldset, form, label, legend,


### PR DESCRIPTION
`<font>` should arguably not be reset, because currently something like `<font family="Comic Sans MS">blah</font>` will reset the font family, which is obviously undesirable...
