### PR TITLE
added support for display: xxx !important, display: box !important included

### DIFF
--- a/lib/nib/box.styl
+++ b/lib/nib/box.styl
@@ -3,11 +3,11 @@
  * Vendor "display: box" support.
  */
 
-display(type)
-  if box == type
-    display: vendor-value(type)
+display(type, args...)
+  if type == box
+    display: vendor-value(type, args)
   else
-    display: type
+    display: arguments
 
 /*
  * Synopsis:

--- a/lib/nib/vendor.styl
+++ b/lib/nib/vendor.styl
@@ -25,12 +25,12 @@ vendor(prop, args, only = null, ignore = null)
  * Vendorize the given value.
  */
 
-vendor-value(arg)
+vendor-value(arg, args...)
   prop = current-property[0]
   for prefix in vendor-prefixes
     unless official == prefix
-      add-property(prop, '-%s-%s' % (prefix arg))
-  arg
+      add-property(prop, '-%s-%s %s' % (prefix arg args))
+  arguments
 
 /*
  * Vendor "box-shadow" support.


### PR DESCRIPTION
there might have been a more elegant solution, but the one I thought of needed `pop()` support to extract things from arguments.

would be a nice addition to the built-ins.

also, ideally this vendor-value would cover situations like `transition: ***transform*** 1.5s, opacity .5s`, but it gets really complicated because you can't count on `transform` being `arguments[0]` so...

maybe the vendor value function could just take the name of the value you want to vendorize and then apply it wherever it occurred in the callees arguments. not sure.

anyways.
