### PR TITLE
Support linear gradients using CSS3PIE

### DIFF
--- a/lib/nib/gradients.styl
+++ b/lib/nib/gradients.styl
@@ -128,6 +128,11 @@ linear-gradient(start, stops...)
       gradient = '-%s-linear-gradient(%s, %s)' % (prefix start stops)   
       add-property(prop, replace(val, '__CALL__', gradient))
 
+  // css3pie
+  if prop == 'background'
+    gradient = 'linear-gradient(%s, %s)' % (start stops)
+    add-property('-pie-background', replace(val, '__CALL__', gradient))
+
   // standard 
   'linear-gradient(%s, %s)' % (start stops)
 


### PR DESCRIPTION
The code `background linear-gradient(top, 0% #46BFD3, 4% #3398B7, 100% #287790)` will result in an extra property being generated `-pie-background` to support http://css3pie.com. This fixes #51.
