### PR TITLE
Preserving importance for opacity, Fixes #58

### DIFF
--- a/lib/nib/vendor.styl
+++ b/lib/nib/vendor.styl
@@ -210,10 +210,10 @@ perspective()
  * Opacity with conditional IE support.
  */
 
-opacity(n)
-  opacity: n
+opacity(n, args...)
+  opacity: n args
   if support-for-ie
-    filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=%s)' % round(n * 100)
+    filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=%s)' % round(n * 100) args
 
 /*
  * Alias the "white-space" property.


### PR DESCRIPTION
Added `args...` for the `opacity`. Some test are failing from the ending whitespace, but I fixed this issue in this [Stylus pull request](https://github.com/LearnBoost/stylus/pull/630)
