### PR TITLE
Reset HTML5 Audio, Video and Canvas tag

### DIFF
--- a/lib/nib/reset.styl
+++ b/lib/nib/reset.styl
@@ -70,3 +70,10 @@ reset-html5()
   section, summary
     reset-box-model()
     display: block
+  audio, canvas, video
+    display inline-block
+    *display inline
+    *zoom 1
+  audio:not([controls]),[hidden]
+    display none
+  


### PR DESCRIPTION
Line 73 - 76: Corrects inline-block display not defined in IE6/7/8/9 & FF3

Line 77 - 78: Addresses styling for 'hidden' attribute not present in IE7/8/9, FF3, S4

According to Normalize.css(https://github.com/necolas/normalize.css)
