### PR TITLE
Remove duplicate imports and defines

### DIFF
--- a/lib/nib/overflow.styl
+++ b/lib/nib/overflow.styl
@@ -1,6 +1,3 @@
-
-@import 'text/ellipsis'
-
 /*
  * Overflow utility. Maps to regular overflow, and adds an ellipsis value.
  *

--- a/lib/nib/vendor.styl
+++ b/lib/nib/vendor.styl
@@ -368,13 +368,6 @@ animation-fill-mode()
   vendor('animation-fill-mode', arguments)
 
 /*
- * Vendor "border-image" support.
- */
-
-border-image()
-  vendor('border-image', arguments, only: webkit moz o official)
-
-/*
  * Vendor "hyphens" support.
  */
 


### PR DESCRIPTION
Most of the warnings created in #81 were fixed in e32a4daf3266af89c463e93c3f68177fb8c52db0 (and I guess either that wasn't published in npm, or nib was stuck in my npm cache) but this commit stops the remaining three from happening.
