### PR TITLE
documentation fix on synopsis for relative() position utility

### DIFF
--- a/lib/nib/positions.styl
+++ b/lib/nib/positions.styl
@@ -1,4 +1,3 @@
-
 // helper
 
 -pos(type, args)
@@ -50,7 +49,7 @@ absolute()
  * 
  * Synopsis:
  * 
- *   absolute: <pos> [n] <pos> [n]
+ *   relative: <pos> [n] <pos> [n]
  * 
  * Examples:
  * 


### PR DESCRIPTION
Looks like a copy/paste error. Just a one-word change in a comment.
