### PR TITLE
Updated vendor prefixes

### DIFF
--- a/lib/nib/vendor.styl
+++ b/lib/nib/vendor.styl
@@ -36,7 +36,7 @@ vendor-value(arg)
  */
 
 box-shadow()
-  vendor('box-shadow', arguments, only: webkit moz official)
+  vendor('box-shadow', arguments, only: webkit official)
 
 /*
  * Vendor "user-select" support.
@@ -151,7 +151,7 @@ background-origin()
  */
 
 background-size()
-  vendor('background-size', arguments, only: webkit moz o official)
+  vendor('background-size', arguments, only: webkit official)
 
 /*
  * Vendor "transform" support.
@@ -445,4 +445,4 @@ border-radius()
         if augmented
           -apply-border-radius(pos)
           pos = ()
-  vendor('border-radius', pos, only: webkit moz official) unless augmented
+  vendor('border-radius', pos, only: webkit official) unless augmented


### PR DESCRIPTION
-FF 3.6 at ~2.6% market share trending downward, so -moz- prefix can be removed for border-radius & background-size as no longer necessary.
- Removed -o- prefix from background-size as Opera never supported it

Should take care of it all. More info:
- https://github.com/paulirish/css3please/commit/52eaa342330c089b278e669abaedb34cc5889bf1
- http://www.opera.com/docs/specs/presto28/css/o-vendor/
