### PR TITLE
Update opacity FUNction

### DIFF
--- a/lib/nib/vendor.styl
+++ b/lib/nib/vendor.styl
@@ -249,8 +249,8 @@ opacity(n, args...)
       -ms-filter: none
       filter: none
     else
-      -ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=%s)' % ieValue args
-      filter: 'alpha(opacity=%s)' % ieValue args
+      -ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=%s)' % val args
+      filter: 'alpha(opacity=%s)' % val args
 
 /*
  * Alias the "white-space" property.


### PR DESCRIPTION
This clears up issue where passing a value of 100 in IE (to override previous semi-opaque state) borks it and ensures support in IE5-8 in all the different varieties of life (http://www.quirksmode.org/css/opacity.html)
