### PR TITLE
Updated stylus dependency, fixes #89

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
       "connect": "1.x"
     , "jade": "0.22.0"
-    , "stylus": "0.19.x"
+    , "stylus": "0.27.x"
     , "mocha": "*"
     , "should": "*"
     , "canvas": "*"


### PR DESCRIPTION
The stylus version in dependancies is very old now, so I've updated it to the recent one, so the tests would run ok.
