### PR TITLE
+ hide() mixin for text-indent: 100% method

### DIFF
--- a/lib/nib/text/hide-text.styl
+++ b/lib/nib/text/hide-text.styl
@@ -2,12 +2,7 @@
  * Hide text.
  */
 
-hide()
+hide-text()
   text-indent: 100%
   white-space: nowrap
   overflow: hidden
-
-hide-text()
-  text-indent: -99999em
-  overflow: hidden
-  text-align: left


### PR DESCRIPTION
- measurable performance gains over 99999em method
- added as hide() mixin instead of changing hide-text() for backwards
  compatability; in almost every case it's a drop-in replacement but best
  not to screw with what people expect from their mixins
