### PR TITLE
Make sure text is invisible when replace-text is used.

### DIFF
--- a/lib/nib/text/hide-text.styl
+++ b/lib/nib/text/hide-text.styl
@@ -3,6 +3,6 @@
  */
 
 hide-text()
-  text-indent: 100%
+  text-indent: 101%
   white-space: nowrap
   overflow: hidden


### PR DESCRIPTION
Adresses an issue when Firefox shows first pixel of text because of incorrect percentage rounding.
