### PR TITLE
Recent change broke my app =(

### DIFF
--- a/lib/nib/vendor.styl
+++ b/lib/nib/vendor.styl
@@ -324,6 +324,56 @@ box-sizing()
   vendor('box-sizing', arguments, only: webkit moz official)
 
 /*
+ * Vendor "box-orient" support.
+ */
+
+box-orient()
+  vendor('box-orient', arguments, only: webkit moz ms official)
+
+/*
+ * Vendor "box-flex" support.
+ */
+
+box-flex()
+  vendor('box-flex', arguments, only: webkit moz ms official)
+
+/*
+ * Vendor "box-flex-group" support.
+ */
+
+box-flex-group()
+  vendor('box-flex-group', arguments, only: webkit moz official)
+
+/*
+ * Vendor "box-ordinal-group" support.
+ */
+
+box-ordinal-group()
+  vendor('box-ordinal-group', arguments, only: webkit moz ms official)
+
+
+/*
+ * Vendor "box-align" support.
+ */
+
+box-align()
+  vendor('box-align', arguments, only: webkit moz ms official)
+
+/*
+ * Vendor "box-pack" support.
+ */
+
+box-pack()
+  vendor('box-pack', arguments, only: webkit moz ms official)
+
+/*
+ * Vendor "box-direction" support.
+ */
+
+box-direction()
+  vendor('box-direction', arguments, only: webkit moz ms official)
+
+/*
  * Vendor "animation" support.
  */
 


### PR DESCRIPTION
This reverts commit 0094b57447d4f571a8b956b49217851e61d834cf.

These are still necessary! Latest Safari, Chrome, and Firefox still need prefixes...
