### PR TITLE
Fix for perspective as a value and testes for this

### DIFF
--- a/lib/nib/vendor.styl
+++ b/lib/nib/vendor.styl
@@ -278,7 +278,10 @@ backface-visibility()
  */
 
 perspective()
-  vendor('perspective', arguments, only: webkit moz ms official)
+  if mixin
+    vendor('perspective', arguments, only: webkit moz ms official)
+  else
+    'perspective(%s)' % arguments
 
 /*
  * Vendor "perspective-origin" support.

--- a/test/cases/vendor.css
+++ b/test/cases/vendor.css
@@ -132,6 +132,17 @@ button {
   -moz-transform: rotateY(45deg);
   transform: rotateY(45deg);
 }
+button {
+  -o-transform: perspective(500px);
+  -webkit-transform: perspective(500px);
+  -moz-transform: perspective(500px);
+  transform: perspective(500px);
+}
+button {
+  -webkit-perspective: 500;
+  -moz-perspective: 500;
+  perspective: 500;
+}
 section {
   -o-border-image: url("image.png") 20% stretch stretch;
   -webkit-border-image: url("image.png") 20% stretch stretch;

--- a/test/cases/vendor.styl
+++ b/test/cases/vendor.styl
@@ -69,6 +69,12 @@ button
 button
   transform: rotateY(45deg)
 
+button
+  transform: perspective(500px)
+
+button
+  perspective: 500
+
 section
   border-image: url("image.png") 20% stretch stretch;
 


### PR DESCRIPTION
Changed the `perspective()` mixin so it now looks at it's context using the `mixin` variable (?) and added tests covering this issue.
