### PR TITLE
Only assign 'support-for-ie' if it is not defined already.

### DIFF
--- a/lib/nib/config.styl
+++ b/lib/nib/config.styl
@@ -2,7 +2,7 @@
  * Support for ie defaulting to true.
  */
 
-support-for-ie = true
+support-for-ie ?= true
 
 /*
  * Default vendor prefixes.


### PR DESCRIPTION
;)
