### PR TITLE
Fix duplicate box-flex properties

### DIFF
--- a/lib/nib/flex.styl
+++ b/lib/nib/flex.styl
@@ -45,7 +45,7 @@ align-items(align)
 
 flex(growth)
   // obsolete
-  vendor('box-flex', growth)
+  box-flex growth
 
   // new
   vendor('flex', arguments, only: webkit official)

--- a/lib/nib/vendor.styl
+++ b/lib/nib/vendor.styl
@@ -338,7 +338,7 @@ box-orient()
  */
 
 box-flex()
-  vendor('box-flex', arguments, only: webkit moz ms official)
+  vendor('box-flex', arguments, only: webkit moz o ms official)
 
 /*
  * Vendor "box-flex-group" support.

--- a/test/cases/flex.css
+++ b/test/cases/flex.css
@@ -17,9 +17,6 @@ section div {
   -moz-box-flex: 1;
   -o-box-flex: 1;
   -ms-box-flex: 1;
-  -webkit-box-flex: 1;
-  -moz-box-flex: 1;
-  -ms-box-flex: 1;
   box-flex: 1;
   -webkit-flex: 1 0;
   flex: 1 0;


### PR DESCRIPTION
New flex box syntax uses vendor(box-flex) as a fallback but box-flex is already prefixed and results duplicate properties in CSS.
