### PR TITLE
Vendor font-smoothing property

### DIFF
--- a/lib/nib/vendor.styl
+++ b/lib/nib/vendor.styl
@@ -495,6 +495,12 @@ text-size-adjust()
   vendor('text-size-adjust', arguments, only: official webkit ms)
 
 /*
+ * Vendor "font-smoothing" support, webkit only.
+ */
+font-smoothing()
+  vendor('font-smoothing', arguments, only: webkit)
+
+/*
  * Helper for border-radius().
  */
 


### PR DESCRIPTION
For the time being, it's webkit only.
