### PR TITLE
image mixin does not scale properly if size is omitted

### DIFF
--- a/lib/nib/image.styl
+++ b/lib/nib/image.styl
@@ -5,7 +5,7 @@
  * adding an @2x variant.
  */
 
-image(path, w = auto, h = auto)
+image(path, w = 100%, h = auto)
   background-image: url(path)
   @media all and (-webkit-min-device-pixel-ratio: 1.5)
     ext = extname(path)


### PR DESCRIPTION
Using the `image` mixin without specifying the size results in `background-size: auto auto`. This results in an unscaled image in retina displays.  `background-size: 100% auto`, however, works.

This patch changes the default width to 100%.
