### PR TITLE
Quote -ms-filter value for opacity()

### DIFF
--- a/lib/nib/vendor.styl
+++ b/lib/nib/vendor.styl
@@ -315,8 +315,8 @@ opacity(n, args...)
       -ms-filter: none
       filter: none
     else
-      -ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=%s)' % val args
       filter: 'alpha(opacity=%s)' % val args
+      -ms-filter: '"progid:DXImageTransform.Microsoft.Alpha(Opacity=%s)"' % val args
 
 /*
  * Vendor "text-size-adjust"


### PR DESCRIPTION
From Microsoft [documentation](http://msdn.microsoft.com/en-us/library/ie/ms530752(v=vs.85\).aspx):

```
When you use -ms-filter, enclose the progid in single quotes (') or
double quotes (")
```

This is because the stuff after -ms-filter has a colon in it, which is non-standard CSS sytnax.
