### PR TITLE
arrow mixins

### DIFF
--- a/lib/nib/arrow.styl
+++ b/lib/nib/arrow.styl
@@ -1,0 +1,34 @@
+// common helper
+-arrow(size)
+  font: 0/0 undef
+  width: 0
+  height: 0
+  border: size solid transparent
+
+  _border-color: magenta if support-for-ie
+  _filter: chroma(color=magenta) if support-for-ie
+
+
+/*
+ * Generate an arrow (base on border)
+ */
+
+arrow-up(size = 4px, color = #000)
+  -arrow(size)
+  border-top: none
+  border-bottom-color: color
+
+arrow-down(size = 4px, color = #000)
+  -arrow(size)
+  border-bottom: none
+  border-top-color: color
+
+arrow-left(size = 4px, color = #000)
+  -arrow(size)
+  border-left: none
+  border-right-color: color
+
+arrow-right(size = 4px, color = #000)
+  -arrow(size)
+  border-right: none
+  border-left-color: color

--- a/lib/nib/index.styl
+++ b/lib/nib/index.styl
@@ -1,3 +1,4 @@
+@import 'arrow'
 @import 'border'
 @import 'clearfix'
 @import 'color-image'


### PR DESCRIPTION
border based arrow, support ie6+

```stylus
arrow-up(size=4px, color=#000)
arrow-down(size=4px, color=#000)
arrow-left(size=4px, color=#000)
arrow-right(size=4px, color=#000)
```

example
```stylus
arrow-up(10px, #FFF)

//yields
font: 0/0 undef
width: 0
height: 0
border: 10px solid transparent

_border-color: magenta
_filter: chroma(color=magenta)

border-top: none
border-bottom-color: #FFF
```

DEMO http://jsfiddle.net/aRDZw/2/