### PR TITLE
allow gradients stops to accept an array

### DIFF
--- a/lib/nib/gradients.styl
+++ b/lib/nib/gradients.styl
@@ -108,6 +108,7 @@ linear-gradient(start, stops...)
   prop = current-property[0]
   val = current-property[1]
 
+  stops = stops[0] if length(stops) == 1 and length(stops[0]) > 1
   if start is a 'color'
     unshift(stops, start)
     start = top


### PR DESCRIPTION
this allows to send stops as an array, hence enabling linear-gradient overloading

suppose you define:

```
custom-linear-gradient(start, stops...)
    //do stuff
    linear-gradient(start, stops)
```
