### PR TITLE
Fix a small typo when production mode is required

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
     "type": "git",
     "url": "git://github.com/visionmedia/nib.git"
   },
+  "dependencies" : {
+    "stylus": "0.28.x"
+  },
   "devDependencies": {
       "connect": "1.x"
     , "jade": "0.22.0"
-    , "stylus": "0.28.x"
     , "mocha": "*"
     , "should": "*"
     , "canvas": "*"


### PR DESCRIPTION
At production the nib.js requires stylus whereas other packages are optional. When we request the installation of node modules via npm install --production it does not work.
The correction offers the stylus at Production and DevTime
