### PR TITLE
Add support for background-size keywords

### DIFF
--- a/lib/nib/image.styl
+++ b/lib/nib/image.styl
@@ -21,4 +21,6 @@ image(path, w = auto, h = auto, min_pixel_ratio = 1.5)
     ext = extname(path)
     path = pathjoin(dirname(path), basename(path, ext) + '@2x' + ext)
     background-image: url(path)
+    if w in (cover contain) and h == auto
+        h = null
     background-size: w h

--- a/test/cases/image.css
+++ b/test/cases/image.css
@@ -16,3 +16,21 @@
     background-size: 50px 100px;
   }
 }
+#logo {
+  background-image: url("/images/branding/logo.main.png");
+}
+@media all and (-webkit-min-device-pixel-ratio:1.5),(min--moz-device-pixel-ratio:1.5),(-o-min-device-pixel-ratio:1.5/1),(min-device-pixel-ratio:1.5),(min-resolution:138dpi),(min-resolution:1.5dppx) {
+  #logo {
+    background-image: url("/images/branding/logo.main@2x.png");
+    background-size: cover;
+  }
+}
+#logo {
+  background-image: url("/images/branding/logo.main.png");
+}
+@media all and (-webkit-min-device-pixel-ratio:1.5),(min--moz-device-pixel-ratio:1.5),(-o-min-device-pixel-ratio:1.5/1),(min-device-pixel-ratio:1.5),(min-resolution:138dpi),(min-resolution:1.5dppx) {
+  #logo {
+    background-image: url("/images/branding/logo.main@2x.png");
+    background-size: contain;
+  }
+}

--- a/test/cases/image.styl
+++ b/test/cases/image.styl
@@ -5,3 +5,9 @@
 
 #logo
   image: '/images/branding/logo.main.png' 50px 100px
+
+#logo
+  image: '/images/branding/logo.main.png' cover
+
+#logo
+  image: '/images/branding/logo.main.png' contain


### PR DESCRIPTION
Allows the following syntax:

```
image '/mr-t.png' cover
```

Fixes #182
