### PR TITLE
Removed not needed anymore `replace` function

### DIFF
--- a/lib/nib/gradients.styl
+++ b/lib/nib/gradients.styl
@@ -2,20 +2,6 @@
 @import 'config'
 
 /*
- * Replace the given str with val in the expr.
- */
-
-replace(expr, str, val)
-  expr = clone(expr)
-  for e, i in expr
-    if length(e) > 1
-      expr[i] = replace(e, str, val)
-    else
-      if str == e
-        expr[i] = val
-  expr
-
-/*
  * Implicit color stop position.
  */
 
@@ -85,15 +71,6 @@ std-stop(color, pos)
 
 linear-gradient(start, stops...)
   error('color stops required') unless length(stops)
-  // if current-property
-  //   if start is a 'color'
-  //     unshift(stops, start)
-  //     start = top
-  //   if start[0] is a 'unit'
-  //     if has-canvas
-  //       img = linear-gradient-image(start, stops)
-  //       add-property(prop, replace(val, '__CALL__', img))
-  //     start = start[1]
 
   unquote('linear-gradient(' + join(', ',arguments) + ')')
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/visionmedia/nib.git"
   },
   "dependencies": {
-    "stylus": "~0.35.1"
+    "stylus": "~0.37.0"
   },
   "devDependencies": {
     "connect": "1.x",


### PR DESCRIPTION
1. Removed not used in nib anymore `replace` function. This is important, because in Stylus 0.36.0 a proper `replace` function appeared, and if you'd include nib, things would go wrong, 'cause its replace overrides Stylus' replace.
2. Updated Stylus in package.json to `0.37.0`, it's the latest version and there is no reason not to use it :)
3. Removed commented code for old gradient mixin, as we now use a new one.
