### PR TITLE
Autoprefixer Integration

### DIFF
--- a/lib/nib.js
+++ b/lib/nib.js
@@ -10,6 +10,7 @@
  */
 
 var stylus = require('stylus')
+  , autoprefixer = require('autoprefixer-stylus')
   , nodes = stylus.nodes
   , utils = stylus.utils
   , Canvas
@@ -49,6 +50,8 @@ exports.path = __dirname;
 function plugin() {
   return function(style){
     style.include(__dirname);
+
+    autoprefixer()(style);
 
     if (Canvas) {
       style.define('has-canvas', nodes.true);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "git://github.com/visionmedia/nib.git"
   },
   "dependencies": {
-    "stylus": "~0.37.0"
+    "stylus": "~0.37.0",
+    "autoprefixer-stylus": "0.0.x"
   },
   "devDependencies": {
     "connect": "1.x",


### PR DESCRIPTION
This PR will integrate autoprefixer into nib by default, and remove a lot of vendor maintenance stuff. Initial commit here just adds it to the pipeline, a lot of work still left to carefully strip the vendor-handling pieces from nib without breaking anything or removing functionality like the node-canvas stuff.
