### PR TITLE
Inline-block with conditional IE support

### DIFF
--- a/lib/nib/vendor.styl
+++ b/lib/nib/vendor.styl
@@ -265,14 +265,14 @@ perspective-origin()
  * Inline-block with conditional IE support.
  */
 
-display( _mode )
-  if _mode == 'inline-block'
-    display inline-block
+display(mode, args...)
+  if mode == 'inline-block'
+    display inline-block args
     if support-for-ie
       zoom 1
-      *display inline
+      *display inline args
   else
-    display _mode
+    display mode args
 
 /*
  * Opacity with conditional IE support.


### PR DESCRIPTION
A snippet that I miss in every project where I use nib. If `opacity` has place here, then `inline-block` also should be there

``` javascript
/*
 * Inline-block with conditional IE support.
 */
display(mode, args...)
  if mode == 'inline-block'
    display inline-block args
    if support-for-ie
      zoom 1
      *display inline args
  else
    display mode args
```
