### PR TITLE
Image mixin refactor

### DIFF
--- a/lib/nib/image.styl
+++ b/lib/nib/image.styl
@@ -2,21 +2,18 @@
  * Define background-image as `path` with optional width and height, adding an
  * @2x variant.
  *
- * affected by github.com/LearnBoost/stylus/issues/1050 and
- * github.com/LearnBoost/stylus/issues/1038 ... refactor when those are closed
  */
 
 image(path, w = auto, h = auto, min_pixel_ratio = 1.5)
   background-image: url(path)
 
-  s = 'all and (-webkit-min-device-pixel-ratio:' + min_pixel_ratio + '),'
-  s = s + '(min--moz-device-pixel-ratio:' + min_pixel_ratio + '),'
-  s = s + '(-o-min-device-pixel-ratio:' + min_pixel_ratio + '/1),'
-  s = s + '(min-device-pixel-ratio:' + min_pixel_ratio + '),'
-  s = s + '(min-resolution:' + unit(min_pixel_ratio*92, dpi) + '),'
-  s = s + '(min-resolution:' + unit(min_pixel_ratio, dppx) + ')'
+  @media all and (-webkit-min-device-pixel-ratio: min_pixel_ratio),
+    (min--moz-device-pixel-ratio: min_pixel_ratio),
+    (-o-min-device-pixel-ratio: min_pixel_ratio/1),
+    (min-device-pixel-ratio: min_pixel_ratio),
+    (min-resolution: unit(min_pixel_ratio*92, dpi)),
+    (min-resolution: unit(min_pixel_ratio, dppx))
 
-  @media s
     ext = extname(path)
     path = pathjoin(dirname(path), basename(path, ext) + '@2x' + ext)
     background-image: url(path)

--- a/test/cases/image.css
+++ b/test/cases/image.css
@@ -1,7 +1,7 @@
 #logo {
   background-image: url("/images/branding/logo.main.png");
 }
-@media all and (-webkit-min-device-pixel-ratio:1.5),(min--moz-device-pixel-ratio:1.5),(-o-min-device-pixel-ratio:1.5/1),(min-device-pixel-ratio:1.5),(min-resolution:138dpi),(min-resolution:1.5dppx) {
+@media all and (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 1.5/1), (min-device-pixel-ratio: 1.5), (min-resolution: 138dpi), (min-resolution: 1.5dppx) {
   #logo {
     background-image: url("/images/branding/logo.main@2x.png");
     background-size: auto auto;
@@ -10,7 +10,7 @@
 #logo {
   background-image: url("/images/branding/logo.main.png");
 }
-@media all and (-webkit-min-device-pixel-ratio:1.5),(min--moz-device-pixel-ratio:1.5),(-o-min-device-pixel-ratio:1.5/1),(min-device-pixel-ratio:1.5),(min-resolution:138dpi),(min-resolution:1.5dppx) {
+@media all and (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 1.5/1), (min-device-pixel-ratio: 1.5), (min-resolution: 138dpi), (min-resolution: 1.5dppx) {
   #logo {
     background-image: url("/images/branding/logo.main@2x.png");
     background-size: 50px 100px;
@@ -19,7 +19,7 @@
 #logo {
   background-image: url("/images/branding/logo.main.png");
 }
-@media all and (-webkit-min-device-pixel-ratio:1.5),(min--moz-device-pixel-ratio:1.5),(-o-min-device-pixel-ratio:1.5/1),(min-device-pixel-ratio:1.5),(min-resolution:138dpi),(min-resolution:1.5dppx) {
+@media all and (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 1.5/1), (min-device-pixel-ratio: 1.5), (min-resolution: 138dpi), (min-resolution: 1.5dppx) {
   #logo {
     background-image: url("/images/branding/logo.main@2x.png");
     background-size: cover;
@@ -28,7 +28,7 @@
 #logo {
   background-image: url("/images/branding/logo.main.png");
 }
-@media all and (-webkit-min-device-pixel-ratio:1.5),(min--moz-device-pixel-ratio:1.5),(-o-min-device-pixel-ratio:1.5/1),(min-device-pixel-ratio:1.5),(min-resolution:138dpi),(min-resolution:1.5dppx) {
+@media all and (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 1.5/1), (min-device-pixel-ratio: 1.5), (min-resolution: 138dpi), (min-resolution: 1.5dppx) {
   #logo {
     background-image: url("/images/branding/logo.main@2x.png");
     background-size: contain;

--- a/test/cases/image.css
+++ b/test/cases/image.css
@@ -34,3 +34,14 @@
     background-size: contain;
   }
 }
+@media all {
+  #logo {
+    background-image: url("/images/branding/logo.main.png");
+  }
+@media all and (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 1.5/1), (min-device-pixel-ratio: 1.5), (min-resolution: 138dpi), (min-resolution: 1.5dppx) {
+    #logo {
+      background-image: url("/images/branding/logo.main@2x.png");
+      background-size: auto auto;
+    }
+}
+}

--- a/test/cases/image.styl
+++ b/test/cases/image.styl
@@ -11,3 +11,7 @@
 
 #logo
   image: '/images/branding/logo.main.png' contain
+
+@media all
+  #logo
+    image: '/images/branding/logo.main.png'


### PR DESCRIPTION
Fixes issue outlined in https://github.com/visionmedia/nib/issues/276.

The image mixin fails when nested inside a media query, and this pull request resolves that issue using code supplied in the associated Stylus ticket.

An additional test has been written for this case, and all tests are passing based on the current Stylus dependency.

Note that this outputs nested media queries, whereas using 0.48.1 results in flattened media queries. I would update the dependency and test case output file but an additional test related to linear gradients also fails when using latest Stylus.
