### PR TITLE
Remove -webkit-gradient from the output CSS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,14 +9,11 @@ body
 
 ```css
 body {
-  background: -webkit-gradient(linear,
-    left top,
-    left bottom,
-    color-stop(0, #fff),
-    color-stop(1, #000));
-  background: -webkit-linear-gradient(top, #fff 0%, #000 100%);
-  background: -moz-linear-gradient(top, #fff 0%, #000 100%);
-  background: linear-gradient(top, #fff 0%, #000 100%);
+  background: -webkit-linear-gradient(top, #fff, #000);
+  background: -moz-linear-gradient(top, #fff, #000);
+  background: -o-linear-gradient(top, #fff, #000);
+  background: -ms-linear-gradient(top, #fff, #000);
+  background: linear-gradient(to bottom, #fff, #000);
 }
 ```
 


### PR DESCRIPTION
According to https://github.com/visionmedia/nib/issues/94#issuecomment-19504293 the support for legacy -webkit-gradient has been dropped. This should be removed from the docs as well to avoid confusion.
