### PR TITLE
Fix flex-basis, flex-grow and flex-shrink for IE10 by adding -ms-flex-preferred-size, -ms-flex-positive and -ms-flex-negative

### DIFF
--- a/lib/nib/flex.styl
+++ b/lib/nib/flex.styl
@@ -100,14 +100,17 @@ flex-grow(growth)
 
   // new
   if flex in flex-version
+    vendor('flex-positive', arguments, only: ms)
     vendor('flex-grow', arguments, only: webkit official)
 
 flex-basis()
   if flex in flex-version
+    vendor('flex-preferred-size', arguments, only: ms)
     vendor('flex-basis', arguments, only: webkit official)
 
 flex-shrink()
   if flex in flex-version
+    vendor('flex-negative', arguments, only: ms)
     vendor('flex-shrink', arguments, only: webkit official)
 
 flex(growth)

--- a/test/cases/flex.css
+++ b/test/cases/flex.css
@@ -246,6 +246,13 @@ section {
   display: inline-box !important;
 }
 section {
+  -webkit-box-flex: 1;
+  -moz-box-flex: 1;
+  -o-box-flex: 1;
+  -ms-box-flex: 1;
+  box-flex: 1;
+}
+section {
   display: -webkit-flex;
   display: flex;
   -webkit-flex-direction: row;
@@ -268,4 +275,19 @@ section {
 section {
   display: -webkit-inline-flex !important;
   display: inline-flex !important;
+}
+section {
+  -ms-flex-positive: 1;
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+}
+section {
+  -ms-flex-negative: 0;
+  -webkit-flex-shrink: 0;
+  flex-shrink: 0;
+}
+section {
+  -ms-flex-preferred-size: 50%;
+  -webkit-flex-basis: 50%;
+  flex-basis: 50%;
 }

--- a/test/cases/flex.styl
+++ b/test/cases/flex.styl
@@ -72,6 +72,9 @@ section
 section
   display: inline-flex !important
 
+section
+  flex-grow 1
+
 // New property conditional rendering
 flex-version = flex
 
@@ -90,3 +93,12 @@ section
 
 section
   display: inline-flex !important
+
+section
+  flex-grow 1
+
+section
+  flex-shrink 0
+
+section
+  flex-basis 50%


### PR DESCRIPTION
IE 10 uses the following format for [flex](https://msdn.microsoft.com/en-us/library/ie/hh673531(v=vs.85).aspx) property:
```
-ms-flex: <positive-flex> <negative-flex> <preferred-size>
```

And single props for each argument: `-ms-flex-positive`, `-ms-flex-negative` and `-ms-flex-preferred-size` (there is no `flex-grow`, `flex-shrink` and `flex-basis` in IE 10). I can't find an original ms doc for them, but I have tested and they are exist in IE10 and work for me. Also, for example, in [autoprefixer-core](https://github.com/postcss/autoprefixer-core) they're used too for [flex-basis](https://github.com/postcss/autoprefixer-core/blob/master/lib/hacks/flex-basis.coffee#L5), [flex-grow](https://github.com/postcss/autoprefixer-core/blob/master/lib/hacks/flex-grow.coffee#L5) and [flex-shrink](https://github.com/postcss/autoprefixer-core/blob/master/lib/hacks/flex-shrink.coffee#L5).